### PR TITLE
Accept fluentd IP to be a DNS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ SRC = lib/argtable3.c \
 	lib/sha1.c \
 	lib/js0n.c \
 	lib/map.c \
-	src/geoloc-server.c
+	src/geoloc-server.c \
+	src/fluentd.c
 
 OBJ = $(SRC:.c=.o)
 

--- a/src/fluentd.c
+++ b/src/fluentd.c
@@ -1,0 +1,51 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+
+#include "fluentd.h"
+
+
+int
+fluentd_init(struct fluentd *fluentd, const char *ip, int port)
+{
+    if (!ip || port < 0) {
+        return -1;
+    }
+
+    memset(fluentd, 0, sizeof(*fluentd));
+
+    fluentd->sockaddr.sin_family = AF_INET;
+    fluentd->sockaddr.sin_port = htons(port);
+
+    if ((fluentd->sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
+        fprintf(stderr, "fluentd_init: unable to create socket: %s\n", strerror(errno));
+        return -1;
+    }
+
+    // inet_aton returns 0 on error
+    if (inet_aton(ip, &(fluentd->sockaddr.sin_addr)) == 0) {
+        fprintf(stderr, "fluentd_init: invalid IP address '%s'\n", ip);
+        return -1;
+    }
+
+    return 0;
+}
+
+int
+fluentd_sendmsg(struct fluentd *fluentd, const char *msg)
+{
+    int ret;
+
+    ret = sendto(
+        fluentd->sock, msg, strlen(msg), 0,
+        (struct sockaddr *)&(fluentd->sockaddr), sizeof(fluentd->sockaddr)
+    );
+
+    if (ret < 0) {
+        fprintf(stderr, "fluentd_sendmsg: unable to send message - %s\n", strerror(errno));
+        return -1;
+    }
+    return 0;
+}

--- a/src/fluentd.c
+++ b/src/fluentd.c
@@ -18,6 +18,7 @@ fluentd_init(struct fluentd *fluentd, const char *addr, int port)
     }
 
     memset(fluentd, 0, sizeof(*fluentd));
+    fluentd->sock = -1;
 
     if (!(host = gethostbyname(addr))) {
         fprintf(stderr, "fluentd_init: unable to gethostbyname '%s'\n", addr);
@@ -40,6 +41,10 @@ int
 fluentd_sendmsg(struct fluentd *fluentd, const char *msg)
 {
     int ret;
+
+    if (fluentd->sock < 0) {
+        return -1;
+    }
 
     ret = sendto(
         fluentd->sock, msg, strlen(msg), 0,

--- a/src/fluentd.c
+++ b/src/fluentd.c
@@ -3,30 +3,33 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/socket.h>
+#include <netdb.h>
 
 #include "fluentd.h"
 
 
 int
-fluentd_init(struct fluentd *fluentd, const char *ip, int port)
+fluentd_init(struct fluentd *fluentd, const char *addr, int port)
 {
-    if (!ip || port < 0) {
+    struct hostent *host;
+
+    if (!addr || port < 0) {
         return -1;
     }
 
     memset(fluentd, 0, sizeof(*fluentd));
 
+    if (!(host = gethostbyname(addr))) {
+        fprintf(stderr, "fluentd_init: unable to gethostbyname '%s'\n", addr);
+        return -1;
+    }
+
     fluentd->sockaddr.sin_family = AF_INET;
+    memcpy(&fluentd->sockaddr.sin_addr, host->h_addr, host->h_length);
     fluentd->sockaddr.sin_port = htons(port);
 
     if ((fluentd->sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) < 0) {
         fprintf(stderr, "fluentd_init: unable to create socket: %s\n", strerror(errno));
-        return -1;
-    }
-
-    // inet_aton returns 0 on error
-    if (inet_aton(ip, &(fluentd->sockaddr.sin_addr)) == 0) {
-        fprintf(stderr, "fluentd_init: invalid IP address '%s'\n", ip);
         return -1;
     }
 

--- a/src/fluentd.h
+++ b/src/fluentd.h
@@ -1,42 +1,15 @@
-#include<arpa/inet.h>
-#include<sys/socket.h>
-#include <time.h>
+#ifndef FLUENTD_H_
+#define FLUENTD_H_
 
-int connect_fluentd(char* fluentd_ip, int fluentd_port,
-        struct sockaddr_in* si_fluentd, int *nb_connection_attempts,
-        int* last_connection_attempt) {
-  if (fluentd_port == -1 || strcmp("", fluentd_ip) == 0) {
-      return -1;
-  }
-  if (nb_connection_attempts > 0 &&
-          (int)time(NULL) < (*last_connection_attempt + *nb_connection_attempts * 60)) {
-      return -4;
-  }
-  int s;
-  *last_connection_attempt = (int) time(NULL);
-  *nb_connection_attempts = *nb_connection_attempts + 1;
-  if ( (s=socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) == -1) {
-      fprintf(stderr, "Unable to open socket to connect to fluentd\n");
-      return -2;
-  }
-  if (inet_aton(fluentd_ip , &si_fluentd->sin_addr) == 0)  {
-     fprintf(stderr, "inet_aton() failed\n");
-     return -3;
-  }
+#include <sys/types.h>
 
-  *nb_connection_attempts = 0;
-  return s;
-}
+struct fluentd {
+    int sock;
+    struct sockaddr_in sockaddr;
 
-void send_msg_fluentd(char* msg, int *s, struct sockaddr_in* si_fluentd,
-        char* fluentd_ip, int fluentd_port, int slen,
-        int *nb_connection_attempts, int* last_connection_attempt) {
-    if (*s < 0) {
-        *s = connect_fluentd(fluentd_ip, fluentd_port, si_fluentd,
-                nb_connection_attempts, last_connection_attempt);
-        return;
-    }
-    if (sendto(*s, msg, strlen(msg) , 0 , (struct sockaddr *) si_fluentd, slen)==-1) {
-      fprintf(stderr, "Unable to send message %s to fluentd\n", msg);
-    }
-}
+};
+
+int fluentd_init(struct fluentd *fluentd, const char *ip, int port);
+int fluentd_sendmsg(struct fluentd *fluentd, const char *msg);
+
+#endif

--- a/src/fluentd.h
+++ b/src/fluentd.h
@@ -9,7 +9,7 @@ struct fluentd {
 
 };
 
-int fluentd_init(struct fluentd *fluentd, const char *ip, int port);
+int fluentd_init(struct fluentd *fluentd, const char *addr, int port);
 int fluentd_sendmsg(struct fluentd *fluentd, const char *msg);
 
 #endif

--- a/src/geoloc-server.c
+++ b/src/geoloc-server.c
@@ -77,14 +77,14 @@ int main (int argc, char** argv) {
     url_users = malloc(strlen(url_users_arg->sval[0]));
     sprintf(url_users, "%s", url_users_arg->sval[0]);
   }
-  int fluend_port = -1;
+  int fluentd_port = -1;
   if (fluentd_port_arg->count == 1) {
-      fluend_port = *(fluentd_port_arg->ival);
+      fluentd_port = *(fluentd_port_arg->ival);
   }
-  char* fluend_ip = "";
+  char* fluentd_ip = "";
   if (fluentd_ip_arg->count == 1) {
-      fluend_ip = malloc(strlen(fluentd_ip_arg->sval[0]));
-      sprintf(fluend_ip, "%s", fluentd_ip_arg->sval[0]);
+      fluentd_ip = malloc(strlen(fluentd_ip_arg->sval[0]));
+      sprintf(fluentd_ip, "%s", fluentd_ip_arg->sval[0]);
   }
   map_str_t map_users;
   map_init(&map_users);
@@ -126,7 +126,7 @@ int main (int argc, char** argv) {
         exit(1);
   }
   return main_loop(c, authentication_activated, &map_users, sock,
-          listening_port, fluend_ip, fluend_port);
+          listening_port, fluentd_ip, fluentd_port);
 
   err_bind:             printf("Error binding socket. You need to be root for ports under 1024. binding to: %d     Exiting...\n", listening_port);
     return 1;

--- a/src/geoloc-server.c
+++ b/src/geoloc-server.c
@@ -81,11 +81,12 @@ int main (int argc, char** argv) {
   if (fluentd_port_arg->count == 1) {
       fluentd_port = *(fluentd_port_arg->ival);
   }
-  char* fluentd_ip = "";
+  char* fluentd_ip = NULL;
   if (fluentd_ip_arg->count == 1) {
       fluentd_ip = malloc(strlen(fluentd_ip_arg->sval[0]));
       sprintf(fluentd_ip, "%s", fluentd_ip_arg->sval[0]);
   }
+
   map_str_t map_users;
   map_init(&map_users);
   if (authentication_activated)


### PR DESCRIPTION
`--fluentdip` can now be a domain name, and not only an IP address.  It was required to work properly with `APITaxi_devel`.

Also:

- some refactoring
- remove useless "reconnection" on error (for a UDP socket)